### PR TITLE
manually require devise gem

### DIFF
--- a/lib/devise_login_cookie/strategy.rb
+++ b/lib/devise_login_cookie/strategy.rb
@@ -1,3 +1,5 @@
+require 'devise'
+
 module DeviseLoginCookie
 
   class Strategy < ::Devise::Strategies::Authenticatable


### PR DESCRIPTION
Zeus is moronically picky and fails to start unless this is specified
