### PR TITLE
Mongoid support

### DIFF
--- a/lib/devise_login_cookie/strategy.rb
+++ b/lib/devise_login_cookie/strategy.rb
@@ -36,7 +36,7 @@ module DeviseLoginCookie
 
     def resource
       # returns nil when user is missing.
-      @resource ||= mapping.to.where(:id => cookie.id).first
+      @resource ||= mapping.to.find(cookie.id) rescue nil
     end
 
     def pass


### PR DESCRIPTION
Use ActiveModel.find to retrieve database object instead of where() in order to support Mongoid. This should be backwards compatible with ActiveRecord.
